### PR TITLE
Feature/F-11: Parent Deletion Cascade Implementation

### DIFF
--- a/.tasks/250713/f-11.md
+++ b/.tasks/250713/f-11.md
@@ -1,0 +1,130 @@
+# F-11 · Parent Deletion Cascade — Task Checklist
+
+## Checklist
+
+**IMPORTANT**: When starting a new task, read @../../docs/task_mcp_spec_and_plan.md for context.
+
+- [x] **S-01** (XS) Add `errors.py` → `CascadeError` & `ProtectedObjectError`
+  - Created `cascade_error.py` with `CascadeError` class for cascade deletion operation errors
+  - Created `protected_object_error.py` with `ProtectedObjectError` class for protected children deletion blocking
+  - Updated `__init__.py` to export both new exceptions
+  - Added comprehensive unit tests for both exception classes
+  - All 670 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-02** (S) Implement `fs_utils.recursive_delete(path)` with dry-run mode
+  - Implemented `recursive_delete(path: Path, dry_run: bool = False) -> list[Path]` function in `fs_utils.py`
+  - Added import for `shutil` module for safe directory removal
+  - Function supports both single file and recursive directory deletion
+  - Dry-run mode returns list of paths that would be deleted without actually deleting
+  - Includes comprehensive input validation and security checks
+  - Uses `shutil.rmtree` for safe recursive directory removal
+  - Added 12 comprehensive unit tests covering all scenarios (single files, directories, nested structures, Trellis hierarchy, error cases, special characters)
+  - All 682 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-03** (S) Extend `path_resolver.children_of(kind, id)` → list descendant paths
+  - Implemented `children_of(kind: str, obj_id: str, project_root: Path) -> list[Path]` function in `path_resolver.py`
+  - Function returns all descendant paths for a given object in the hierarchical structure
+  - For projects: Returns all epics, features, and tasks under the project
+  - For epics: Returns all features and tasks under the epic
+  - For features: Returns all tasks under the feature
+  - For tasks: Returns empty list (tasks have no children)
+  - Added helper function `_add_tasks_from_feature()` to collect tasks from both tasks-open and tasks-done directories
+  - Includes comprehensive input validation and error handling
+  - Returns paths in sorted order for consistent output
+  - Added 22 comprehensive unit tests covering all scenarios (complete hierarchies, empty objects, error cases, edge cases, complex hierarchies, ID prefix handling)
+  - All 703 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-04** (S) Update `updateObject` RPC: when patch sets `status=deleted`, invoke cascade
+  - Added cascade deletion logic to `updateObject` RPC method in `server.py`
+  - Detects when `yamlPatch` contains `status=deleted` and triggers cascade deletion
+  - Uses `children_of()` to find all descendant paths of the object being deleted
+  - Checks for protected children (tasks with `in-progress` or `review` status)
+  - Raises `ProtectedObjectError` if protected children exist, preventing deletion
+  - Performs cascade deletion using `recursive_delete()` if no protected children
+  - Returns comprehensive result with list of deleted paths in `cascade_deleted` field
+  - Integrates with existing error handling by wrapping exceptions in `TrellisValidationError`
+  - All 703 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-05** (XS) Safeguard: abort if any child Task is `in-progress` or `review`
+  - Added `force` parameter to `updateObject` method with default value `False`
+  - Updated method documentation to describe the force parameter behavior
+  - Modified safeguard logic to check force flag before raising `ProtectedObjectError`
+  - When `force=False` (default): Raises `ProtectedObjectError` if protected children exist
+  - When `force=True`: Bypasses safeguard and proceeds with cascade deletion
+  - All 703 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-06** (XS) CLI: add `--force` flag to `trellis-mcp delete` sub-command
+  - Added new `delete` sub-command to CLI with kind and object_id arguments
+  - Implemented `--force` flag to bypass protected children safeguards
+  - Command calls `updateObject` with `status=deleted` and `force` parameter
+  - Follows same error handling and output patterns as other CLI commands
+  - Provides comprehensive help text with examples for all object types
+  - All 703 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-07** (S) CLI prompt ("⚠️  Delete Epic E-foo and 7 descendants? [y/N]")
+  - Added confirmation prompt to CLI delete command using `click.confirm()`
+  - Implemented descendant counting using `children_of()` function before deletion
+  - Shows appropriate message: "⚠️  Delete Epic E-foo and 7 descendants? [y/N]" when descendants exist
+  - Shows simpler message: "⚠️  Delete Epic E-foo? [y/N]" when no descendants exist
+  - Gracefully handles user cancellation with `click.Abort` exception
+  - Maintains all existing functionality and error handling patterns
+  - All 703 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-08** (XS) Unit tests: dry-run returns correct deletion list
+  - Added `test_recursive_delete_dry_run_matches_actual_deletion` test function in `test_fs_utils.py`
+  - Test verifies that dry-run returns identical deletion list to actual deletion mode
+  - Creates identical directory structures in separate temp directories 
+  - Compares dry-run results with actual deletion results to ensure consistency
+  - Validates same number of paths, same relative structure, and same ordering
+  - Ensures all paths are resolved absolute paths as required by the function
+  - All 704 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-09** (S) Unit tests: protected child in progress → raises `ProtectedObjectError`
+  - Added `TestProtectedObjectDeletion` class to `test_server.py` with comprehensive test coverage
+  - Implemented tests for various scenarios: epic/feature/project deletion with protected tasks
+  - Tests verify `ProtectedObjectError` is raised when attempting to delete objects with tasks in `in-progress` or `review` status
+  - Tests verify force deletion bypasses the protection mechanism
+  - Tests verify correct error messages are generated
+  - Added `StatusEnum.DELETED` to status enum and allowed statuses for all object kinds
+  - Updated transition matrices in all schema models to allow transitions to `deleted` from any status
+  - Fixed validation logic to support cascade deletion functionality
+  - Updated existing validation tests to reflect new transition behavior (done → deleted is now valid)
+  - All new tests passing: 5 tests added covering epic, feature, project deletion scenarios
+  - All existing tests updated and passing: 101 validation tests, 709 total tests
+- [x] **S-10** (M) Integration test: create nested Project→Epic→Feature→Task tree, delete Epic, verify repo contains no orphan files/folders
+  - Implemented `test_parent_deletion_cascade_integration` in `tests/integration/test_crud_operations.py`
+  - Creates complete Project→Epic→Feature→Task hierarchy with tasks in both open and done states
+  - Uses `updateObject` with `status=deleted` to trigger cascade deletion of epic
+  - Verifies all .md files are properly deleted from the filesystem
+  - Confirms no orphan files remain in the repository structure
+  - Ensures parent project remains intact and functional after deletion
+  - Validates cascade_deleted response contains all expected deleted file paths
+  - Fixed CLI delete command to properly use FastMCP client interface
+  - Test passes comprehensive verification of cascade deletion functionality
+  - All 711 tests passing, all quality checks (format, lint, type-check) passing
+- [x] **S-11** (XS) Docs: update Quick-start & README with deletion example
+  - Added comprehensive deletion examples to README.md Quick Start section (step 5)
+  - Demonstrated basic task deletion, feature/epic deletion with confirmation prompts 
+  - Showed cascade deletion output with example file listings
+  - Included --force flag usage for protected children scenarios
+  - Examples match actual CLI command syntax and expected output format
+  - All 710 tests passing, all quality checks (format, lint, type-check) passing
+
+### Quality Gates
+* No orphan files remain after deletion.
+* Deleting a parent with active (`in-progress`/`review`) children is blocked unless `--force`.
+* All tests & pre-commit hooks pass on CI matrix.
+
+### Relevant Files
+* `/src/trellis_mcp/exceptions/cascade_error.py` - CascadeError exception class
+* `/src/trellis_mcp/exceptions/protected_object_error.py` - ProtectedObjectError exception class  
+* `/src/trellis_mcp/exceptions/__init__.py` - Updated exports for new exceptions
+* `/tests/unit/test_exceptions.py` - Unit tests for new exception classes
+* `/src/trellis_mcp/fs_utils.py` - Added recursive_delete function with dry-run mode
+* `/tests/unit/test_fs_utils.py` - Added comprehensive unit tests for recursive_delete function, including test that verifies dry-run returns identical deletion list to actual deletion
+* `/src/trellis_mcp/path_resolver.py` - Added children_of function and _add_tasks_from_feature helper function
+* `/tests/unit/test_path_resolver.py` - Added comprehensive unit tests for children_of function
+* `/src/trellis_mcp/server.py` - Added cascade deletion logic to updateObject RPC method, added force parameter to bypass safeguards
+* `/src/trellis_mcp/cli.py` - Added delete sub-command with --force flag that calls updateObject with status=deleted, added confirmation prompt with descendant counting
+* `/src/trellis_mcp/schema/status_enum.py` - Added StatusEnum.DELETED for cascade deletion support
+* `/src/trellis_mcp/schema/base_schema.py` - Added StatusEnum.DELETED to allowed statuses for all object kinds
+* `/src/trellis_mcp/schema/project.py` - Updated transition matrix to allow transitions to deleted from any status
+* `/src/trellis_mcp/schema/epic.py` - Updated transition matrix to allow transitions to deleted from any status
+* `/src/trellis_mcp/schema/feature.py` - Updated transition matrix to allow transitions to deleted from any status
+* `/src/trellis_mcp/schema/task.py` - Updated transition matrix to allow transitions to deleted from any status
+* `/tests/unit/test_server.py` - Added TestProtectedObjectDeletion class with comprehensive tests for ProtectedObjectError scenarios
+* `/tests/unit/test_validation.py` - Updated existing validation tests to reflect new transition behavior (done → deleted is now valid)
+* `/tests/integration/test_crud_operations.py` - Added test_parent_deletion_cascade_integration integration test for complete cascade deletion verification
+* `/README.md` - Added comprehensive deletion examples to Quick Start section demonstrating CLI delete command usage

--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ uv pip install -e .
    }
    ```
 
+5. **Delete objects with cascade deletion:**
+   ```bash
+   # Delete a task (no children to cascade)
+   trellis-mcp delete task T-001
+   
+   # Delete a feature with confirmation prompt
+   trellis-mcp delete feature F-user-management
+   # Output: ⚠️  Delete Feature F-user-management and 5 descendants? [y/N]
+   
+   # Delete an epic and all its children
+   trellis-mcp delete epic E-auth
+   # Output: ⚠️  Delete Epic E-auth and 12 descendants? [y/N]
+   
+   # Force delete even if children have protected status (in-progress/review)
+   trellis-mcp delete project P-001 --force
+   ```
+   
+   Example output after successful deletion:
+   ```
+   ✓ Deleted epic E-auth
+     Cascade deleted 12 items:
+       - planning/projects/P-001/epics/E-auth/epic.md
+       - planning/projects/P-001/epics/E-auth/features/F-login/feature.md
+       - planning/projects/P-001/epics/E-auth/features/F-login/tasks-open/T-login-form.md
+       - planning/projects/P-001/epics/E-auth/features/F-login/tasks-done/2025-01-15T10:30:00-T-setup-db.md
+       - ... (and 8 more files)
+   ```
+
 ## Requirements
 
 - Python 3.12+

--- a/src/trellis_mcp/exceptions/__init__.py
+++ b/src/trellis_mcp/exceptions/__init__.py
@@ -3,12 +3,16 @@
 Contains custom exception classes used throughout the system.
 """
 
+from .cascade_error import CascadeError
 from .invalid_status_for_completion import InvalidStatusForCompletion
 from .no_available_task import NoAvailableTask
 from .prerequisites_not_complete import PrerequisitesNotComplete
+from .protected_object_error import ProtectedObjectError
 
 __all__ = [
+    "CascadeError",
     "InvalidStatusForCompletion",
     "NoAvailableTask",
     "PrerequisitesNotComplete",
+    "ProtectedObjectError",
 ]

--- a/src/trellis_mcp/exceptions/cascade_error.py
+++ b/src/trellis_mcp/exceptions/cascade_error.py
@@ -1,0 +1,13 @@
+"""Exception for errors during cascade deletion operations."""
+
+
+class CascadeError(Exception):
+    """Raised when cascade deletion encounters an error.
+
+    This exception is raised during parent deletion cascade operations when:
+    1. Filesystem errors occur during recursive deletion
+    2. Orphaned files or directories are detected after deletion
+    3. Other system-level errors prevent clean cascade deletion
+    """
+
+    pass

--- a/src/trellis_mcp/exceptions/protected_object_error.py
+++ b/src/trellis_mcp/exceptions/protected_object_error.py
@@ -1,0 +1,15 @@
+"""Exception for when deletion is blocked due to protected children."""
+
+
+class ProtectedObjectError(Exception):
+    """Raised when attempting to delete a parent with protected children.
+
+    This exception is raised when attempting to delete a parent object that has
+    child objects in protected states:
+    1. Tasks with status 'in-progress' or 'review'
+    2. Other child objects that cannot be safely deleted
+
+    The deletion is blocked unless the --force flag is used.
+    """
+
+    pass

--- a/src/trellis_mcp/schema/base_schema.py
+++ b/src/trellis_mcp/schema/base_schema.py
@@ -63,14 +63,30 @@ class BaseSchemaModel(TrellisBaseModel):
                 # Validate status for the specific kind
                 # Define allowed statuses per kind
                 allowed_statuses = {
-                    KindEnum.PROJECT: {StatusEnum.DRAFT, StatusEnum.IN_PROGRESS, StatusEnum.DONE},
-                    KindEnum.EPIC: {StatusEnum.DRAFT, StatusEnum.IN_PROGRESS, StatusEnum.DONE},
-                    KindEnum.FEATURE: {StatusEnum.DRAFT, StatusEnum.IN_PROGRESS, StatusEnum.DONE},
+                    KindEnum.PROJECT: {
+                        StatusEnum.DRAFT,
+                        StatusEnum.IN_PROGRESS,
+                        StatusEnum.DONE,
+                        StatusEnum.DELETED,
+                    },
+                    KindEnum.EPIC: {
+                        StatusEnum.DRAFT,
+                        StatusEnum.IN_PROGRESS,
+                        StatusEnum.DONE,
+                        StatusEnum.DELETED,
+                    },
+                    KindEnum.FEATURE: {
+                        StatusEnum.DRAFT,
+                        StatusEnum.IN_PROGRESS,
+                        StatusEnum.DONE,
+                        StatusEnum.DELETED,
+                    },
                     KindEnum.TASK: {
                         StatusEnum.OPEN,
                         StatusEnum.IN_PROGRESS,
                         StatusEnum.REVIEW,
                         StatusEnum.DONE,
+                        StatusEnum.DELETED,
                     },
                 }
 

--- a/src/trellis_mcp/schema/epic.py
+++ b/src/trellis_mcp/schema/epic.py
@@ -21,7 +21,7 @@ class EpicModel(BaseSchemaModel):
 
     # Status transition matrix for epics
     _valid_transitions = {
-        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS},
-        StatusEnum.IN_PROGRESS: {StatusEnum.DONE},
-        StatusEnum.DONE: set(),  # No transitions from done
+        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS, StatusEnum.DELETED},
+        StatusEnum.IN_PROGRESS: {StatusEnum.DONE, StatusEnum.DELETED},
+        StatusEnum.DONE: {StatusEnum.DELETED},  # Only deletion allowed from done
     }

--- a/src/trellis_mcp/schema/feature.py
+++ b/src/trellis_mcp/schema/feature.py
@@ -21,7 +21,7 @@ class FeatureModel(BaseSchemaModel):
 
     # Status transition matrix for features
     _valid_transitions = {
-        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS},
-        StatusEnum.IN_PROGRESS: {StatusEnum.DONE},
-        StatusEnum.DONE: set(),  # No transitions from done
+        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS, StatusEnum.DELETED},
+        StatusEnum.IN_PROGRESS: {StatusEnum.DONE, StatusEnum.DELETED},
+        StatusEnum.DONE: {StatusEnum.DELETED},  # Only deletion allowed from done
     }

--- a/src/trellis_mcp/schema/project.py
+++ b/src/trellis_mcp/schema/project.py
@@ -21,7 +21,7 @@ class ProjectModel(BaseSchemaModel):
 
     # Status transition matrix for projects
     _valid_transitions = {
-        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS},
-        StatusEnum.IN_PROGRESS: {StatusEnum.DONE},
-        StatusEnum.DONE: set(),  # No transitions from done
+        StatusEnum.DRAFT: {StatusEnum.IN_PROGRESS, StatusEnum.DELETED},
+        StatusEnum.IN_PROGRESS: {StatusEnum.DONE, StatusEnum.DELETED},
+        StatusEnum.DONE: {StatusEnum.DELETED},  # Only deletion allowed from done
     }

--- a/src/trellis_mcp/schema/status_enum.py
+++ b/src/trellis_mcp/schema/status_enum.py
@@ -19,3 +19,4 @@ class StatusEnum(str, Enum):
     REVIEW = "review"
     DONE = "done"
     DRAFT = "draft"
+    DELETED = "deleted"

--- a/src/trellis_mcp/schema/task.py
+++ b/src/trellis_mcp/schema/task.py
@@ -21,8 +21,16 @@ class TaskModel(BaseSchemaModel):
 
     # Status transition matrix for tasks (includes shortcuts)
     _valid_transitions = {
-        StatusEnum.OPEN: {StatusEnum.IN_PROGRESS, StatusEnum.DONE},  # Can skip to done
-        StatusEnum.IN_PROGRESS: {StatusEnum.REVIEW, StatusEnum.DONE},  # Can skip to done
-        StatusEnum.REVIEW: {StatusEnum.DONE},
-        StatusEnum.DONE: set(),  # No transitions from done
+        StatusEnum.OPEN: {
+            StatusEnum.IN_PROGRESS,
+            StatusEnum.DONE,
+            StatusEnum.DELETED,
+        },  # Can skip to done
+        StatusEnum.IN_PROGRESS: {
+            StatusEnum.REVIEW,
+            StatusEnum.DONE,
+            StatusEnum.DELETED,
+        },  # Can skip to done
+        StatusEnum.REVIEW: {StatusEnum.DONE, StatusEnum.DELETED},
+        StatusEnum.DONE: {StatusEnum.DELETED},  # Only deletion allowed from done
     }

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,56 @@
+"""Tests for exception classes.
+
+This module tests the exception classes for proper initialization and inheritance.
+"""
+
+import pytest
+
+from trellis_mcp.exceptions import CascadeError, ProtectedObjectError
+
+
+class TestCascadeError:
+    """Test CascadeError exception class."""
+
+    def test_cascade_error_can_be_raised(self):
+        """Test that CascadeError can be raised and caught."""
+        with pytest.raises(CascadeError):
+            raise CascadeError("Test cascade error")
+
+    def test_cascade_error_with_message(self):
+        """Test that CascadeError correctly stores message."""
+        error = CascadeError("Test cascade error message")
+        assert str(error) == "Test cascade error message"
+
+    def test_cascade_error_inherits_from_exception(self):
+        """Test that CascadeError inherits from Exception."""
+        error = CascadeError("Test error")
+        assert isinstance(error, Exception)
+
+    def test_cascade_error_no_message(self):
+        """Test that CascadeError can be created without message."""
+        error = CascadeError()
+        assert str(error) == ""
+
+
+class TestProtectedObjectError:
+    """Test ProtectedObjectError exception class."""
+
+    def test_protected_object_error_can_be_raised(self):
+        """Test that ProtectedObjectError can be raised and caught."""
+        with pytest.raises(ProtectedObjectError):
+            raise ProtectedObjectError("Test protected object error")
+
+    def test_protected_object_error_with_message(self):
+        """Test that ProtectedObjectError correctly stores message."""
+        error = ProtectedObjectError("Test protected object error message")
+        assert str(error) == "Test protected object error message"
+
+    def test_protected_object_error_inherits_from_exception(self):
+        """Test that ProtectedObjectError inherits from Exception."""
+        error = ProtectedObjectError("Test error")
+        assert isinstance(error, Exception)
+
+    def test_protected_object_error_no_message(self):
+        """Test that ProtectedObjectError can be created without message."""
+        error = ProtectedObjectError()
+        assert str(error) == ""

--- a/tests/unit/test_fs_utils.py
+++ b/tests/unit/test_fs_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from trellis_mcp.fs_utils import ensure_parent_dirs
+from trellis_mcp.fs_utils import ensure_parent_dirs, recursive_delete
 
 
 class TestEnsureParentDirs:
@@ -212,3 +212,414 @@ class TestEnsureParentDirs:
 
             # Verify new parent directory was created
             assert new_file.parent.exists()
+
+
+class TestRecursiveDelete:
+    """Test cases for recursive_delete function."""
+
+    def test_recursive_delete_single_file_dry_run(self):
+        """Test recursive_delete with single file in dry-run mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create a test file
+            test_file = tmp_path / "test.txt"
+            test_file.write_text("test content")
+
+            # Dry-run deletion
+            deleted_paths = recursive_delete(test_file, dry_run=True)
+
+            # Should return the file path
+            assert len(deleted_paths) == 1
+            assert deleted_paths[0] == test_file.resolve()
+
+            # File should still exist after dry-run
+            assert test_file.exists()
+
+    def test_recursive_delete_single_file_actual(self):
+        """Test recursive_delete with single file - actual deletion."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create a test file
+            test_file = tmp_path / "test.txt"
+            test_file.write_text("test content")
+
+            # Actual deletion
+            deleted_paths = recursive_delete(test_file, dry_run=False)
+
+            # Should return the file path
+            assert len(deleted_paths) == 1
+            assert deleted_paths[0] == test_file.resolve()
+
+            # File should be deleted
+            assert not test_file.exists()
+
+    def test_recursive_delete_empty_directory_dry_run(self):
+        """Test recursive_delete with empty directory in dry-run mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create an empty directory
+            test_dir = tmp_path / "test_dir"
+            test_dir.mkdir()
+
+            # Dry-run deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=True)
+
+            # Should return the directory path
+            assert len(deleted_paths) == 1
+            assert deleted_paths[0] == test_dir.resolve()
+
+            # Directory should still exist after dry-run
+            assert test_dir.exists()
+
+    def test_recursive_delete_empty_directory_actual(self):
+        """Test recursive_delete with empty directory - actual deletion."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create an empty directory
+            test_dir = tmp_path / "test_dir"
+            test_dir.mkdir()
+
+            # Actual deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=False)
+
+            # Should return the directory path
+            assert len(deleted_paths) == 1
+            assert deleted_paths[0] == test_dir.resolve()
+
+            # Directory should be deleted
+            assert not test_dir.exists()
+
+    def test_recursive_delete_nested_structure_dry_run(self):
+        """Test recursive_delete with nested directory structure in dry-run mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create nested structure
+            test_dir = tmp_path / "test_dir"
+            subdir1 = test_dir / "subdir1"
+            subdir2 = test_dir / "subdir2"
+            subdir1.mkdir(parents=True)
+            subdir2.mkdir(parents=True)
+
+            # Create files in different directories
+            file1 = test_dir / "file1.txt"
+            file2 = subdir1 / "file2.txt"
+            file3 = subdir2 / "file3.txt"
+
+            file1.write_text("content1")
+            file2.write_text("content2")
+            file3.write_text("content3")
+
+            # Dry-run deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=True)
+
+            # Should return all paths (3 files + 3 directories)
+            assert len(deleted_paths) == 6
+
+            # Files should be in the list
+            expected_files = {file1.resolve(), file2.resolve(), file3.resolve()}
+            expected_dirs = {test_dir.resolve(), subdir1.resolve(), subdir2.resolve()}
+
+            deleted_files = {p for p in deleted_paths if p.is_file()}
+            deleted_dirs = {p for p in deleted_paths if p.is_dir()}
+
+            assert deleted_files == expected_files
+            assert deleted_dirs == expected_dirs
+
+            # Everything should still exist after dry-run
+            assert test_dir.exists()
+            assert subdir1.exists()
+            assert subdir2.exists()
+            assert file1.exists()
+            assert file2.exists()
+            assert file3.exists()
+
+    def test_recursive_delete_nested_structure_actual(self):
+        """Test recursive_delete with nested directory structure - actual deletion."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create nested structure
+            test_dir = tmp_path / "test_dir"
+            subdir1 = test_dir / "subdir1"
+            subdir2 = test_dir / "subdir2"
+            subdir1.mkdir(parents=True)
+            subdir2.mkdir(parents=True)
+
+            # Create files in different directories
+            file1 = test_dir / "file1.txt"
+            file2 = subdir1 / "file2.txt"
+            file3 = subdir2 / "file3.txt"
+
+            file1.write_text("content1")
+            file2.write_text("content2")
+            file3.write_text("content3")
+
+            # Actual deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=False)
+
+            # Should return all paths (3 files + 3 directories)
+            assert len(deleted_paths) == 6
+
+            # Everything should be deleted
+            assert not test_dir.exists()
+            assert not subdir1.exists()
+            assert not subdir2.exists()
+            assert not file1.exists()
+            assert not file2.exists()
+            assert not file3.exists()
+
+    def test_recursive_delete_trellis_structure_dry_run(self):
+        """Test recursive_delete with Trellis MCP project structure in dry-run mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create Trellis project structure
+            project_dir = tmp_path / "P-test-project"
+            epic_dir = project_dir / "epics" / "E-test-epic"
+            feature_dir = epic_dir / "features" / "F-test-feature"
+            tasks_open = feature_dir / "tasks-open"
+            tasks_done = feature_dir / "tasks-done"
+
+            # Create directories
+            tasks_open.mkdir(parents=True)
+            tasks_done.mkdir(parents=True)
+
+            # Create files
+            project_file = project_dir / "project.md"
+            epic_file = epic_dir / "epic.md"
+            feature_file = feature_dir / "feature.md"
+            task_open = tasks_open / "T-open-task.md"
+            task_done = tasks_done / "2025-07-15T10:00:00-T-done-task.md"
+
+            project_file.write_text("project content")
+            epic_file.write_text("epic content")
+            feature_file.write_text("feature content")
+            task_open.write_text("open task content")
+            task_done.write_text("done task content")
+
+            # Dry-run deletion of entire project
+            deleted_paths = recursive_delete(project_dir, dry_run=True)
+
+            # Should return all paths
+            assert len(deleted_paths) > 0
+
+            # All files should be in the list
+            expected_files = {
+                project_file.resolve(),
+                epic_file.resolve(),
+                feature_file.resolve(),
+                task_open.resolve(),
+                task_done.resolve(),
+            }
+
+            deleted_files = {p for p in deleted_paths if p.is_file()}
+            assert expected_files.issubset(deleted_files)
+
+            # Everything should still exist after dry-run
+            assert project_dir.exists()
+            assert epic_dir.exists()
+            assert feature_dir.exists()
+            assert tasks_open.exists()
+            assert tasks_done.exists()
+            assert project_file.exists()
+            assert epic_file.exists()
+            assert feature_file.exists()
+            assert task_open.exists()
+            assert task_done.exists()
+
+    def test_recursive_delete_with_invalid_type_raises_error(self):
+        """Test that recursive_delete raises TypeError for non-Path objects."""
+        with pytest.raises(TypeError, match="Expected pathlib.Path object"):
+            recursive_delete("not/a/path/object")  # type: ignore
+
+        with pytest.raises(TypeError, match="Expected pathlib.Path object"):
+            recursive_delete(123)  # type: ignore
+
+    def test_recursive_delete_nonexistent_path_raises_error(self):
+        """Test that recursive_delete raises FileNotFoundError for non-existent paths."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            nonexistent_path = tmp_path / "does_not_exist"
+
+            with pytest.raises(FileNotFoundError, match="Path does not exist"):
+                recursive_delete(nonexistent_path)
+
+    def test_recursive_delete_handles_path_ordering(self):
+        """Test that recursive_delete returns paths in correct deletion order."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create nested structure
+            test_dir = tmp_path / "test_dir"
+            subdir = test_dir / "subdir"
+            subdir.mkdir(parents=True)
+
+            # Create files
+            file1 = test_dir / "file1.txt"
+            file2 = subdir / "file2.txt"
+            file1.write_text("content1")
+            file2.write_text("content2")
+
+            # Dry-run deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=True)
+
+            # Verify that deeper paths come before shallower ones
+            # (files before their containing directories)
+            path_depths = [(len(p.parts), p) for p in deleted_paths]
+            sorted_by_depth = sorted(path_depths, key=lambda x: x[0], reverse=True)
+
+            # The returned paths should already be in the correct order
+            assert [p for _, p in sorted_by_depth] == deleted_paths
+
+    def test_recursive_delete_dry_run_preserves_permissions(self):
+        """Test that dry-run mode doesn't modify file permissions or timestamps."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create a test file
+            test_file = tmp_path / "test.txt"
+            test_file.write_text("test content")
+
+            # Get original stats
+            original_stat = test_file.stat()
+
+            # Dry-run deletion
+            recursive_delete(test_file, dry_run=True)
+
+            # File should still exist and be unchanged
+            assert test_file.exists()
+            new_stat = test_file.stat()
+
+            # Permissions and basic stats should be unchanged
+            assert original_stat.st_mode == new_stat.st_mode
+            assert original_stat.st_size == new_stat.st_size
+
+    def test_recursive_delete_handles_special_characters(self):
+        """Test recursive_delete with files containing special characters."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # Create files with special characters
+            special_files = [
+                tmp_path / "file with spaces.txt",
+                tmp_path / "file-with-dashes.txt",
+                tmp_path / "file_with_underscores.txt",
+                tmp_path / "file.with.dots.txt",
+            ]
+
+            for file_path in special_files:
+                file_path.write_text("content")
+
+            # Create a directory to delete
+            test_dir = tmp_path / "test_dir"
+            test_dir.mkdir()
+
+            # Move files to the directory
+            for file_path in special_files:
+                new_path = test_dir / file_path.name
+                file_path.rename(new_path)
+
+            # Dry-run deletion
+            deleted_paths = recursive_delete(test_dir, dry_run=True)
+
+            # Should handle all special characters correctly
+            assert len(deleted_paths) == 5  # 4 files + 1 directory
+
+            # All files should still exist after dry-run
+            assert test_dir.exists()
+            for file_path in special_files:
+                new_path = test_dir / file_path.name
+                assert new_path.exists()
+
+    def test_recursive_delete_dry_run_matches_actual_deletion(self):
+        """Test that dry-run returns identical deletion list to actual deletion."""
+
+        # Helper function to create identical directory structure
+        def create_test_structure(base_path: Path) -> Path:
+            """Create identical nested structure for testing."""
+            test_dir = base_path / "test_structure"
+
+            # Create nested directories
+            subdir1 = test_dir / "subdir1"
+            subdir2 = test_dir / "subdir2"
+            nested_dir = subdir1 / "nested"
+
+            subdir1.mkdir(parents=True)
+            subdir2.mkdir(parents=True)
+            nested_dir.mkdir(parents=True)
+
+            # Create files at different levels
+            files = [
+                test_dir / "root_file.txt",
+                subdir1 / "file1.txt",
+                subdir2 / "file2.txt",
+                nested_dir / "deep_file.txt",
+                test_dir / "another_root.md",
+            ]
+
+            for file_path in files:
+                file_path.write_text(f"Content of {file_path.name}")
+
+            return test_dir
+
+        with tempfile.TemporaryDirectory() as tmp_dir1, tempfile.TemporaryDirectory() as tmp_dir2:
+            tmp_path1 = Path(tmp_dir1)
+            tmp_path2 = Path(tmp_dir2)
+
+            # Create identical structures
+            structure1 = create_test_structure(tmp_path1)
+            structure2 = create_test_structure(tmp_path2)
+
+            # Run dry-run on first structure
+            dry_run_paths = recursive_delete(structure1, dry_run=True)
+
+            # Run actual deletion on second structure
+            actual_paths = recursive_delete(structure2, dry_run=False)
+
+            # Verify dry-run structure still exists
+            assert structure1.exists()
+
+            # Verify actual deletion structure is gone
+            assert not structure2.exists()
+
+            # Both should return the same number of paths
+            assert len(dry_run_paths) == len(actual_paths)
+
+            # Convert paths to structure-relative names for comparison
+            def get_structure_relative_names(paths: list[Path], base: Path) -> list[str]:
+                """Get relative names from the structure base directory."""
+                base_resolved = base.resolve()
+                result = []
+                for p in paths:
+                    p_resolved = p.resolve()
+                    if p_resolved == base_resolved:
+                        result.append(".")  # The base directory itself
+                    else:
+                        # Get relative path from base directory
+                        try:
+                            rel_path = p_resolved.relative_to(base_resolved)
+                            result.append(str(rel_path))
+                        except ValueError:
+                            # Path is not under base, use just the name
+                            result.append(p_resolved.name)
+                return result
+
+            dry_run_names = get_structure_relative_names(dry_run_paths, structure1)
+            actual_names = get_structure_relative_names(actual_paths, structure2)
+
+            # Both lists should contain the same relative names in the same order
+            assert dry_run_names == actual_names
+
+            # Verify all paths are resolved absolute paths
+            for path in dry_run_paths:
+                assert path.is_absolute(), f"Path {path} should be absolute"
+                assert path == path.resolve(), f"Path {path} should be resolved"
+
+            for path in actual_paths:
+                assert path.is_absolute(), f"Path {path} should be absolute"
+                assert path == path.resolve(), f"Path {path} should be resolved"

--- a/tests/unit/test_path_resolver.py
+++ b/tests/unit/test_path_resolver.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from trellis_mcp.path_resolver import id_to_path, path_to_id, resolve_project_roots
+from trellis_mcp.path_resolver import children_of, id_to_path, path_to_id, resolve_project_roots
 
 
 class TestIdToPath:
@@ -1612,6 +1612,493 @@ class TestResolveProjectRoots:
         # Verify results - should treat project_root as planning directory
         assert scanning_root == tmp_path.parent
         assert path_resolution_root == tmp_path
+
+
+class TestChildrenOf:
+    """Test cases for the children_of function."""
+
+    def test_project_children_complete_hierarchy(self, temp_dir):
+        """Test finding all children of a project with complete hierarchy."""
+        project_root = temp_dir / "planning"
+
+        # Create complete hierarchy
+        project_dir = project_root / "projects" / "P-user-auth"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# User Auth Project")
+
+        # Create epic
+        epic_dir = project_dir / "epics" / "E-authentication"
+        epic_dir.mkdir(parents=True)
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Authentication Epic")
+
+        # Create feature
+        feature_dir = epic_dir / "features" / "F-login"
+        feature_dir.mkdir(parents=True)
+        feature_file = feature_dir / "feature.md"
+        feature_file.write_text("# Login Feature")
+
+        # Create tasks
+        tasks_open_dir = feature_dir / "tasks-open"
+        tasks_open_dir.mkdir()
+        task_open_file = tasks_open_dir / "T-implement-jwt.md"
+        task_open_file.write_text("# Implement JWT Task")
+
+        tasks_done_dir = feature_dir / "tasks-done"
+        tasks_done_dir.mkdir()
+        task_done_file = tasks_done_dir / "2025-07-13T19:12:00-05:00-T-setup-auth.md"
+        task_done_file.write_text("# Setup Auth Task")
+
+        # Test finding all children of project
+        result = children_of("project", "user-auth", project_root)
+
+        # Should return all descendant paths
+        expected_paths = [epic_file, feature_file, task_open_file, task_done_file]
+        assert len(result) == len(expected_paths)
+        for path in expected_paths:
+            assert path in result
+
+    def test_project_children_multiple_epics(self, temp_dir):
+        """Test finding children of a project with multiple epics."""
+        project_root = temp_dir / "planning"
+
+        # Create project with two epics
+        project_dir = project_root / "projects" / "P-ecommerce"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Ecommerce Project")
+
+        # Epic 1
+        epic1_dir = project_dir / "epics" / "E-user-management"
+        epic1_dir.mkdir(parents=True)
+        epic1_file = epic1_dir / "epic.md"
+        epic1_file.write_text("# User Management Epic")
+
+        # Epic 2
+        epic2_dir = project_dir / "epics" / "E-payment"
+        epic2_dir.mkdir(parents=True)
+        epic2_file = epic2_dir / "epic.md"
+        epic2_file.write_text("# Payment Epic")
+
+        # Test finding all children
+        result = children_of("project", "ecommerce", project_root)
+
+        # Should return both epics
+        assert len(result) == 2
+        assert epic1_file in result
+        assert epic2_file in result
+
+    def test_epic_children_complete_hierarchy(self, temp_dir):
+        """Test finding all children of an epic with complete hierarchy."""
+        project_root = temp_dir / "planning"
+
+        # Create epic structure
+        epic_dir = project_root / "projects" / "P-user-auth" / "epics" / "E-authentication"
+        epic_dir.mkdir(parents=True)
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Authentication Epic")
+
+        # Create two features
+        feature1_dir = epic_dir / "features" / "F-login"
+        feature1_dir.mkdir(parents=True)
+        feature1_file = feature1_dir / "feature.md"
+        feature1_file.write_text("# Login Feature")
+
+        feature2_dir = epic_dir / "features" / "F-registration"
+        feature2_dir.mkdir(parents=True)
+        feature2_file = feature2_dir / "feature.md"
+        feature2_file.write_text("# Registration Feature")
+
+        # Create tasks under first feature
+        tasks_open_dir = feature1_dir / "tasks-open"
+        tasks_open_dir.mkdir()
+        task_file = tasks_open_dir / "T-implement-jwt.md"
+        task_file.write_text("# Implement JWT Task")
+
+        # Test finding all children of epic
+        result = children_of("epic", "authentication", project_root)
+
+        # Should return features and tasks
+        expected_paths = [feature1_file, feature2_file, task_file]
+        assert len(result) == len(expected_paths)
+        for path in expected_paths:
+            assert path in result
+
+    def test_feature_children_tasks_only(self, temp_dir):
+        """Test finding children of a feature (only tasks)."""
+        project_root = temp_dir / "planning"
+
+        # Create feature structure
+        feature_dir = (
+            project_root
+            / "projects"
+            / "P-user-auth"
+            / "epics"
+            / "E-authentication"
+            / "features"
+            / "F-login"
+        )
+        feature_dir.mkdir(parents=True)
+        feature_file = feature_dir / "feature.md"
+        feature_file.write_text("# Login Feature")
+
+        # Create tasks
+        tasks_open_dir = feature_dir / "tasks-open"
+        tasks_open_dir.mkdir()
+        task_open_file = tasks_open_dir / "T-implement-jwt.md"
+        task_open_file.write_text("# Implement JWT Task")
+
+        tasks_done_dir = feature_dir / "tasks-done"
+        tasks_done_dir.mkdir()
+        task_done_file = tasks_done_dir / "2025-07-13T19:12:00-05:00-T-setup-auth.md"
+        task_done_file.write_text("# Setup Auth Task")
+
+        # Test finding children of feature
+        result = children_of("feature", "login", project_root)
+
+        # Should return only tasks
+        assert len(result) == 2
+        assert task_open_file in result
+        assert task_done_file in result
+
+    def test_task_children_empty(self, temp_dir):
+        """Test that tasks have no children."""
+        project_root = temp_dir / "planning"
+
+        # Create task structure
+        task_dir = (
+            project_root
+            / "projects"
+            / "P-user-auth"
+            / "epics"
+            / "E-authentication"
+            / "features"
+            / "F-login"
+            / "tasks-open"
+        )
+        task_dir.mkdir(parents=True)
+        task_file = task_dir / "T-implement-jwt.md"
+        task_file.write_text("# Implement JWT Task")
+
+        # Test finding children of task
+        result = children_of("task", "implement-jwt", project_root)
+
+        # Should return empty list
+        assert result == []
+
+    def test_project_children_empty_project(self, temp_dir):
+        """Test finding children of an empty project."""
+        project_root = temp_dir / "planning"
+
+        # Create empty project
+        project_dir = project_root / "projects" / "P-empty"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Empty Project")
+
+        # Test finding children
+        result = children_of("project", "empty", project_root)
+
+        # Should return empty list
+        assert result == []
+
+    def test_epic_children_empty_epic(self, temp_dir):
+        """Test finding children of an empty epic."""
+        project_root = temp_dir / "planning"
+
+        # Create empty epic
+        epic_dir = project_root / "projects" / "P-user-auth" / "epics" / "E-empty"
+        epic_dir.mkdir(parents=True)
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Empty Epic")
+
+        # Test finding children
+        result = children_of("epic", "empty", project_root)
+
+        # Should return empty list
+        assert result == []
+
+    def test_feature_children_empty_feature(self, temp_dir):
+        """Test finding children of an empty feature."""
+        project_root = temp_dir / "planning"
+
+        # Create empty feature
+        feature_dir = (
+            project_root
+            / "projects"
+            / "P-user-auth"
+            / "epics"
+            / "E-authentication"
+            / "features"
+            / "F-empty"
+        )
+        feature_dir.mkdir(parents=True)
+        feature_file = feature_dir / "feature.md"
+        feature_file.write_text("# Empty Feature")
+
+        # Test finding children
+        result = children_of("feature", "empty", project_root)
+
+        # Should return empty list
+        assert result == []
+
+    def test_children_of_with_id_prefix(self, temp_dir):
+        """Test children_of function with prefixed IDs."""
+        project_root = temp_dir / "planning"
+
+        # Create project structure
+        project_dir = project_root / "projects" / "P-user-auth"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# User Auth Project")
+
+        epic_dir = project_dir / "epics" / "E-authentication"
+        epic_dir.mkdir(parents=True)
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Authentication Epic")
+
+        # Test with prefixed ID
+        result = children_of("project", "P-user-auth", project_root)
+
+        # Should work the same as without prefix
+        assert len(result) == 1
+        assert epic_file in result
+
+    def test_children_of_paths_sorted(self, temp_dir):
+        """Test that children_of returns paths in sorted order."""
+        project_root = temp_dir / "planning"
+
+        # Create project with multiple children
+        project_dir = project_root / "projects" / "P-test"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Test Project")
+
+        # Create epics with names that would sort differently
+        epic_z_dir = project_dir / "epics" / "E-z-epic"
+        epic_z_dir.mkdir(parents=True)
+        epic_z_file = epic_z_dir / "epic.md"
+        epic_z_file.write_text("# Z Epic")
+
+        epic_a_dir = project_dir / "epics" / "E-a-epic"
+        epic_a_dir.mkdir(parents=True)
+        epic_a_file = epic_a_dir / "epic.md"
+        epic_a_file.write_text("# A Epic")
+
+        # Test finding children
+        result = children_of("project", "test", project_root)
+
+        # Should be sorted alphabetically
+        assert len(result) == 2
+        assert result[0] == epic_a_file  # A should come before Z
+        assert result[1] == epic_z_file
+
+    def test_children_of_invalid_kind_error(self, temp_dir):
+        """Test that invalid kind raises ValueError."""
+        project_root = temp_dir / "planning"
+
+        with pytest.raises(ValueError, match="Invalid kind 'invalid'"):
+            children_of("invalid", "some-id", project_root)
+
+    def test_children_of_empty_kind_error(self, temp_dir):
+        """Test that empty kind raises ValueError."""
+        project_root = temp_dir / "planning"
+
+        with pytest.raises(ValueError, match="Invalid kind ''"):
+            children_of("", "some-id", project_root)
+
+    def test_children_of_empty_id_error(self, temp_dir):
+        """Test that empty ID raises ValueError."""
+        project_root = temp_dir / "planning"
+
+        with pytest.raises(ValueError, match="Object ID cannot be empty"):
+            children_of("project", "", project_root)
+
+    def test_children_of_whitespace_id_error(self, temp_dir):
+        """Test that whitespace-only ID raises ValueError."""
+        project_root = temp_dir / "planning"
+
+        with pytest.raises(ValueError, match="Object ID cannot be empty"):
+            children_of("project", "   ", project_root)
+
+    def test_children_of_nonexistent_project_error(self, temp_dir):
+        """Test that non-existent project raises FileNotFoundError."""
+        project_root = temp_dir / "planning"
+        project_root.mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError, match="Project with ID 'nonexistent' not found"):
+            children_of("project", "nonexistent", project_root)
+
+    def test_children_of_nonexistent_epic_error(self, temp_dir):
+        """Test that non-existent epic raises FileNotFoundError."""
+        project_root = temp_dir / "planning"
+        project_root.mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError, match="Epic with ID 'nonexistent' not found"):
+            children_of("epic", "nonexistent", project_root)
+
+    def test_children_of_nonexistent_feature_error(self, temp_dir):
+        """Test that non-existent feature raises FileNotFoundError."""
+        project_root = temp_dir / "planning"
+        project_root.mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError, match="Feature with ID 'nonexistent' not found"):
+            children_of("feature", "nonexistent", project_root)
+
+    def test_children_of_complex_hierarchy(self, temp_dir):
+        """Test children_of with a complex multi-level hierarchy."""
+        project_root = temp_dir / "planning"
+
+        # Create complex project structure
+        project_dir = project_root / "projects" / "P-ecommerce"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Ecommerce Project")
+
+        # Epic 1 with features and tasks
+        epic1_dir = project_dir / "epics" / "E-user-management"
+        epic1_dir.mkdir(parents=True)
+        epic1_file = epic1_dir / "epic.md"
+        epic1_file.write_text("# User Management Epic")
+
+        feature1_dir = epic1_dir / "features" / "F-user-profile"
+        feature1_dir.mkdir(parents=True)
+        feature1_file = feature1_dir / "feature.md"
+        feature1_file.write_text("# User Profile Feature")
+
+        task1_dir = feature1_dir / "tasks-open"
+        task1_dir.mkdir()
+        task1_file = task1_dir / "T-update-avatar.md"
+        task1_file.write_text("# Update Avatar Task")
+
+        # Epic 2 with different structure
+        epic2_dir = project_dir / "epics" / "E-payment"
+        epic2_dir.mkdir(parents=True)
+        epic2_file = epic2_dir / "epic.md"
+        epic2_file.write_text("# Payment Epic")
+
+        feature2_dir = epic2_dir / "features" / "F-checkout"
+        feature2_dir.mkdir(parents=True)
+        feature2_file = feature2_dir / "feature.md"
+        feature2_file.write_text("# Checkout Feature")
+
+        task2_dir = feature2_dir / "tasks-done"
+        task2_dir.mkdir()
+        task2_file = task2_dir / "2025-07-13T19:12:00-05:00-T-process-payment.md"
+        task2_file.write_text("# Process Payment Task")
+
+        # Test finding all children of project
+        result = children_of("project", "ecommerce", project_root)
+
+        # Should return all descendant paths
+        expected_paths = [
+            epic1_file,
+            epic2_file,
+            feature1_file,
+            feature2_file,
+            task1_file,
+            task2_file,
+        ]
+        assert len(result) == len(expected_paths)
+        for path in expected_paths:
+            assert path in result
+
+    def test_children_of_edge_cases(self, temp_dir):
+        """Test children_of with edge cases like empty directories."""
+        project_root = temp_dir / "planning"
+
+        # Create project with empty subdirectories
+        project_dir = project_root / "projects" / "P-test"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Test Project")
+
+        # Create empty epics directory
+        epics_dir = project_dir / "epics"
+        epics_dir.mkdir()
+
+        # Create epic with empty features directory
+        epic_dir = epics_dir / "E-test-epic"
+        epic_dir.mkdir()
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Test Epic")
+
+        features_dir = epic_dir / "features"
+        features_dir.mkdir()
+
+        # Test finding children
+        result = children_of("project", "test", project_root)
+
+        # Should return only the epic (no features or tasks)
+        assert len(result) == 1
+        assert epic_file in result
+
+    def test_children_of_tasks_both_directories(self, temp_dir):
+        """Test children_of includes tasks from both open and done directories."""
+        project_root = temp_dir / "planning"
+
+        # Create feature with tasks in both directories
+        feature_dir = (
+            project_root
+            / "projects"
+            / "P-user-auth"
+            / "epics"
+            / "E-authentication"
+            / "features"
+            / "F-login"
+        )
+        feature_dir.mkdir(parents=True)
+        feature_file = feature_dir / "feature.md"
+        feature_file.write_text("# Login Feature")
+
+        # Create tasks in both directories
+        tasks_open_dir = feature_dir / "tasks-open"
+        tasks_open_dir.mkdir()
+        task_open_file = tasks_open_dir / "T-implement-jwt.md"
+        task_open_file.write_text("# Implement JWT Task")
+
+        tasks_done_dir = feature_dir / "tasks-done"
+        tasks_done_dir.mkdir()
+        task_done_file = tasks_done_dir / "2025-07-13T19:12:00-05:00-T-setup-auth.md"
+        task_done_file.write_text("# Setup Auth Task")
+
+        # Test finding children of feature
+        result = children_of("feature", "login", project_root)
+
+        # Should include tasks from both directories
+        assert len(result) == 2
+        assert task_open_file in result
+        assert task_done_file in result
+
+    def test_children_of_id_prefix_stripping(self, temp_dir):
+        """Test that children_of properly strips ID prefixes."""
+        project_root = temp_dir / "planning"
+
+        # Create project structure
+        project_dir = project_root / "projects" / "P-test-project"
+        project_dir.mkdir(parents=True)
+        project_file = project_dir / "project.md"
+        project_file.write_text("# Test Project")
+
+        epic_dir = project_dir / "epics" / "E-test-epic"
+        epic_dir.mkdir(parents=True)
+        epic_file = epic_dir / "epic.md"
+        epic_file.write_text("# Test Epic")
+
+        # Test all prefixes are stripped
+        test_cases = [
+            ("P-test-project", "project"),
+            ("E-test-project", "project"),  # Wrong prefix but should still work
+            ("F-test-project", "project"),
+            ("T-test-project", "project"),
+            ("test-project", "project"),  # No prefix
+        ]
+
+        for test_id, kind in test_cases:
+            result = children_of(kind, test_id, project_root)
+            assert len(result) == 1
+            assert epic_file in result
 
     def test_both_scenarios_return_path_objects(self, tmp_path):
         """Test that both return values are always Path objects."""


### PR DESCRIPTION
## Summary

Implements comprehensive cascade deletion functionality for parent objects (Projects, Epics, Features) with robust safety safeguards and force override capability.

• **Cascade deletion**: Deleting parent objects automatically removes all descendant children
• **Safety safeguards**: Blocks deletion if children have protected status (in-progress/review)  
• **Force override**: `--force` flag bypasses protected children checks when needed
• **Interactive CLI**: Confirmation prompts showing descendant counts before deletion
• **Dry-run support**: Preview deletion operations without actual file removal

## Key Components

### New Exception Classes
- `CascadeError`: For cascade deletion operation errors
- `ProtectedObjectError`: When deletion is blocked by protected children

### Enhanced Utilities
- `fs_utils.recursive_delete()`: Safe recursive deletion with dry-run mode
- `path_resolver.children_of()`: Finds all descendant paths in object hierarchy

### Updated RPC & CLI
- Enhanced `updateObject` RPC with cascade deletion on `status=deleted`
- New `trellis-mcp delete` CLI command with `--force` flag and confirmation prompts
- Added `StatusEnum.DELETED` support across all object schemas

### Comprehensive Testing
- 711 total tests passing (added 41 new tests)
- Unit tests for all new functions and exception classes
- Integration test verifying complete cascade deletion workflow
- Tests for protected object safeguards and force override

## Test Plan

- [x] All 711 tests passing
- [x] All pre-commit hooks passing (format, lint, type-check)
- [x] Cascade deletion removes all descendants from filesystem
- [x] Protected children (in-progress/review tasks) block deletion
- [x] Force flag properly overrides protected children checks
- [x] CLI confirmation prompts work correctly
- [x] Dry-run mode matches actual deletion results
- [x] No orphan files remain after deletion operations
- [x] Integration test covers complete Project→Epic→Feature→Task hierarchy

🤖 Generated with [Claude Code](https://claude.ai/code)